### PR TITLE
access logging improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,8 +645,8 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "linkerd-stack",
  "pin-project",
- "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,8 +645,8 @@ dependencies = [
  "chrono",
  "futures",
  "http",
- "linkerd-stack",
  "pin-project",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,8 +645,10 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "linkerd-identity",
+ "linkerd-proxy-transport",
+ "linkerd-stack",
  "pin-project",
- "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/linkerd/access-log/Cargo.toml
+++ b/linkerd/access-log/Cargo.toml
@@ -12,6 +12,8 @@ chrono = "0.4.15"
 futures = "0.3"
 http = "0.2"
 pin-project = "1"
-tower = { version = "0.4", default-features = false }
+linkerd-stack = { path = "../stack" }
+linkerd-identity = { path = "../identity" }
+linkerd-proxy-transport = { path = "../proxy/transport" }
 tracing = "0.1.19"
 tracing-subscriber = "0.2.12"

--- a/linkerd/access-log/src/tower.rs
+++ b/linkerd/access-log/src/tower.rs
@@ -11,10 +11,9 @@ use tracing::{field, span, Level, Span};
 pub struct AccessLogLayer {}
 
 #[derive(Clone)]
-pub struct AccessLogContext<Svc> {
-    inner: Svc,
+pub struct AccessLogContext<S> {
+    inner: S,
 }
-
 struct ResponseFutureInner {
     span: Span,
     start: Instant,
@@ -76,7 +75,7 @@ where
             %timestamp,
             processing_ns=field::Empty,
             total_ns=field::Empty,
-            method=&request.method().as_str(),
+            method=request.method().as_str(),
             uri=&field::display(&request.uri()),
             version=&field::debug(&request.version()),
             user_agent=get_header("User-Agent"),

--- a/linkerd/access-log/src/tower.rs
+++ b/linkerd/access-log/src/tower.rs
@@ -102,7 +102,7 @@ where
             [chrono::format::Item::Fixed(chrono::format::Fixed::RFC3339)].iter(),
         );
 
-        let span = span!(target: "access_log", Level::TRACE, "http",
+        let span = span!(target: "access_log", Level::INFO, "http",
             %timestamp,
             client.addr = %self.client_addr,
             client.id = self.client_id.as_ref().map(identity::Name::as_ref).unwrap_or_default(),

--- a/linkerd/access-log/src/tracing.rs
+++ b/linkerd/access-log/src/tracing.rs
@@ -79,6 +79,7 @@ where
                 if let Some(fields) = span.extensions().get::<FormattedFields<F>>() {
                     let mut writer = self.make_writer.make_writer();
                     let _ = writeln!(&mut writer, "{}", fields.fields);
+                    println!("access log: {}", fields.fields);
                 }
             }
         }

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -17,6 +17,7 @@ use linkerd_app_core::{
     },
     svc::{self, Param},
     tls,
+    transport::{ClientAddr, Remote},
     transport_header::SessionProtocol,
     Error, NameAddr, NameMatch, Never,
 };
@@ -288,6 +289,12 @@ impl Param<tls::ClientId> for HttpTransportHeader {
     }
 }
 
+impl Param<Remote<ClientAddr>> for HttpTransportHeader {
+    fn param(&self) -> Remote<ClientAddr> {
+        self.client.client_addr
+    }
+}
+
 // === impl HttpLegacy ===
 
 impl<E: Into<Error>> TryFrom<(Result<Option<http::Version>, E>, ClientInfo)> for HttpLegacy {
@@ -319,6 +326,12 @@ impl Param<http::normalize_uri::DefaultAuthority> for HttpLegacy {
 impl Param<Option<identity::Name>> for HttpLegacy {
     fn param(&self) -> Option<identity::Name> {
         Some(self.client.client_id.clone().0)
+    }
+}
+
+impl Param<Remote<ClientAddr>> for HttpLegacy {
+    fn param(&self) -> Remote<ClientAddr> {
+        self.client.client_addr
     }
 }
 

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -141,6 +141,12 @@ impl Param<Option<identity::Name>> for HttpAccept {
     }
 }
 
+impl Param<Remote<ClientAddr>> for HttpAccept {
+    fn param(&self) -> Remote<ClientAddr> {
+        self.tcp.client_addr
+    }
+}
+
 // === impl HttpEndpoint ===
 
 impl Param<http::client::Settings> for HttpEndpoint {

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -160,7 +160,7 @@ impl Settings {
             // Also, ensure that the `tracing` filter configuration will
             // always enable the access log spans.
             let filter = filter.add_directive(
-                "access_log=trace"
+                "access_log=info"
                     .parse()
                     .expect("hard-coded filter directive should always parse"),
             );

--- a/linkerd/tracing/src/test.rs
+++ b/linkerd/tracing/src/test.rs
@@ -10,23 +10,20 @@ pub fn trace_subscriber(default: impl ToString) -> (Dispatch, Handle) {
     let log_level = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
         .unwrap_or_else(|_| default.to_string());
-    let log_format = env::var("LINKERD2_PROXY_LOG_FORMAT").unwrap_or_else(|_| "PLAIN".to_string());
-    env::set_var("LINKERD2_PROXY_LOG_FORMAT", &log_format);
+    // let log_format = env::var("LINKERD2_PROXY_LOG_FORMAT").unwrap_or_else(|_| "PLAIN".to_string());
+    // env::set_var("LINKERD2_PROXY_LOG_FORMAT", &log_format);
     // This may fail, since the global log compat layer may have been
     // initialized by another test.
     let _ = init_log_compat();
-    Settings::default()
-        .filter(log_level)
-        .format(log_format)
-        .test(true)
-        .build()
+    Settings::from_env().filter(log_level).test(true).build()
 }
 
-pub fn with_default_filter(default: impl ToString) -> tracing::dispatcher::DefaultGuard {
-    let (d, _) = trace_subscriber(default);
-    tracing::dispatcher::set_default(&d)
+pub fn with_default_filter(default: impl ToString) -> (tracing::dispatcher::DefaultGuard, Handle) {
+    let (d, handle) = trace_subscriber(default);
+    let default = tracing::dispatcher::set_default(&d);
+    (default, handle)
 }
 
-pub fn trace_init() -> tracing::dispatcher::DefaultGuard {
+pub fn trace_init() -> (tracing::dispatcher::DefaultGuard, Handle) {
     with_default_filter(DEFAULT_LOG)
 }


### PR DESCRIPTION
This branch makes a couple improvements to the access log implementation
added in #601.

In particular, I've added an environment variable to control whether or
not we write the access log:

* The access log is no longer written to stdout, but is instead written
  to a file configured by the `LINKERD2_PROXY_ACCESS_LOG` environment
  variable
* If the `LINKERD2_PROXY_ACCESS_LOG` environment variable is *not* set,
  we don't write the access log
* When the access log is enabled, we modify the global `tracing` filter
  configuration to ensure the access log spans are always enabled.

I've also made the following additional changes:

* I changed the `tracing` level for the access log spans from `TRACE` to
  `INFO`. This way, when the access log is enabled, we can still use
  `tracing`'s [max level filters][1] to filter out `DEBUG` and `TRACE`
  spans. Enabling the `TRACE` level for just the access log would make
  the global max level (which is the most verbose level that's enabled
  *anywhere*) also be `TRACE`, which means we can't benefit from the
  filtering fast path for skipping `DEBUG` and `TRACE` anywhere else.
* Access logs often include information about the client which accessed
  the resource. I've modified the access log implementation to include
  the client's IP address and its identity (if it was meshed). I did
  this by adding a `NewAccessLog` type that implements `NewService` and
  produces `AccessLogContext` services. The `NewService` extracts the
  client information from its target type and passes it to the
  `AccessLogContext` when it's constructed.

[1]:
https://docs.rs/tracing/0.1.26/tracing/subscriber/trait.Subscriber.html#method.max_level_hint